### PR TITLE
Add "Hide out of stock" filter to Proximo Stock list

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -183,6 +183,7 @@
       "emptyList": "Empty List",
       "article": "Article",
       "articles": "Articles",
+      "hideOutOfStock": "Hide out of stock",
       "sortOrder": "Sort by",
       "sortName": "Name",
       "sortNameReverse": "Name (reverse)",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -183,6 +183,7 @@
       "emptyList": "Liste Vide",
       "article": "Article",
       "articles": "Articles",
+      "hideOutOfStock": "Cacher articles en rupture de stock",
       "sortOrder": "Trier par :",
       "sortName": "Nom",
       "sortNameReverse": "Nom (inversé)",

--- a/src/screens/Services/Proximo/ProximoListScreen.tsx
+++ b/src/screens/Services/Proximo/ProximoListScreen.tsx
@@ -150,7 +150,7 @@ function ProximoListScreen(props: Props) {
             {i18n.t('screens.proximo.sortOrder')}
           </Title>
           <Checkbox.Item
-            label="Hide out of stock"
+            label={i18n.t('screens.proximo.hideOutOfStock')}
             status={hideOutOfStock ? 'checked' : 'unchecked'}
             onPress={toggleShowOutOfStock}
           />


### PR DESCRIPTION
Solves #15 .

French translation string may be too long.

![image](https://user-images.githubusercontent.com/23584745/137626564-84adce8d-4069-4a64-84da-3f84e84a31a7.png)
