### PR TITLE
[WIP] - Notification settings

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -374,7 +374,9 @@
         "title": "Edit dashboard",
         "message": "The five items above represent your dashboard.\nYou can replace one of its services by selecting it, and then by tapping the desired new service in the list below.",
         "undo": "Undo changes"
-      }
+      },
+      "notificationsSettings": "Notification Settings",
+      "notificationsSettingsSub": "Manage notifications settings"
     },
     "about": {
       "title": "About",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -374,7 +374,9 @@
         "title": "Modifier la dashboard",
         "message": "Les 5 icônes ci-dessus représentent ta dashboard.\nTu peux remplacer un de ses services en cliquant dessus, puis en sélectionnant le nouveau service de ton choix dans la liste ci-dessous.",
         "undo": "Annuler les changements"
-      }
+      },
+      "notificationsSettings": "Paramètres des notifications",
+      "notificationsSettingsSub": "Choisis les notifications que tu veux recevoir"
     },
     "about": {
       "title": "À Propos",

--- a/src/screens/Other/Settings/SettingsScreen.tsx
+++ b/src/screens/Other/Settings/SettingsScreen.tsx
@@ -18,7 +18,7 @@
  */
 
 import * as React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Linking, Platform, StyleSheet, View } from 'react-native';
 import i18n from 'i18n-js';
 import {
   RadioButton,
@@ -233,6 +233,31 @@ function SettingsScreen() {
     );
   };
 
+  const getButtonItem = (
+    icon: string,
+    title: string,
+    subtitle: string,
+    onPress: () => void
+  ) => {
+    return (
+      <List.Item
+        title={title}
+        description={subtitle}
+        onPress={onPress}
+        left={(props) => (
+          <List.Icon color={props.color} style={props.style} icon={icon} />
+        )}
+        right={(props) => (
+          <List.Icon
+            color={props.color}
+            style={props.style}
+            icon="chevron-right"
+          />
+        )}
+      />
+    );
+  };
+
   const onSelectWashValueChange = (value: string) => {
     if (value != null) {
       proxiwashPreferences.updatePreferences(
@@ -288,6 +313,26 @@ function SettingsScreen() {
             'view-dashboard',
             i18n.t('screens.settings.dashboard'),
             i18n.t('screens.settings.dashboardSub')
+          )}
+          {getButtonItem(
+            'cog',
+            i18n.t('screens.settings.notificationsSettings'),
+            i18n.t('screens.settings.notificationsSettingsSub'),
+            () => {
+              if (Platform.OS === 'ios') {
+                Linking.openURL('app-settings:');
+              } else {
+                Linking.sendIntent(
+                  'android.settings.APP_NOTIFICATION_SETTINGS',
+                  [
+                    {
+                      'android.provider.extra.APP_PACKAGE':
+                        'fr.amicaleinsat.application',
+                    },
+                  ]
+                );
+              }
+            }
           )}
         </List.Section>
       </Card>


### PR DESCRIPTION
Solves #67.

>  Untested on iOS

The code works but the linter complains about syntax here

https://github.com/ClubInfoInsaT/application-amicale/blob/49acb69cb7f49bc5f0eb7c362d15350b086096f9/src/screens/Other/Settings/SettingsScreen.tsx#L325-L333

By changing the syntax like this,

```ts
Linking.sendIntent( 
   'android.settings.APP_NOTIFICATION_SETTINGS', 
   [ 
     { 
       key: 'android.provider.extra.APP_PACKAGE', 
       value: 'fr.amicaleinsat.application', 
     }, 
   ] 
 );
```

there's no error message from the linter but the settings page doesn't open anymore.
