### PR TITLE
feat: add sosinfra service

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -28,7 +28,8 @@
         "equipment": "Book a BBQ or other equipment",
         "washers": "Number of available washers",
         "dryers": "Number of available dryers",
-        "schooling": "Easy access to all your documents and results."
+        "schooling": "Easy access to all your documents and results.",
+        "sosinfra": "Report issues within a building"
       },
       "titles": {
         "yearlyPlanning": "Yearly planning"
@@ -217,7 +218,8 @@
       "bib": "Bib'Box",
       "mails": "INSA Mails",
       "ent": "INSA ENT",
-      "schooling": "My schooling"
+      "schooling": "My schooling",
+      "sosinfra": "SOS Infra"
     },
 
     "login": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -28,7 +28,8 @@
         "equipment": "Réserve un BBQ ou autre matériel",
         "washers": "Nombre de lave-Linges disponibles",
         "dryers": "Nombre de sèche-Linges disponibles",
-        "schooling": "Accéde facilement à tous tes documents et résultats."
+        "schooling": "Accéde facilement à tous tes documents et résultats.",
+        "sosinfra": "Signale un problème dans un bâtiment"
       },
       "titles": {
         "yearlyPlanning": "Planning de l'année"
@@ -217,7 +218,8 @@
       "bib": "Bib'Box",
       "mails": "Mails INSA",
       "ent": "ENT INSA",
-      "schooling": "Ma scolarité"
+      "schooling": "Ma scolarité",
+      "sosinfra": "SOS Infra"
     },
 
     "login": {

--- a/src/constants/Urls.tsx
+++ b/src/constants/Urls.tsx
@@ -80,6 +80,7 @@ export default {
     insaAccount: APP_IMAGES_ENDPOINT + 'Account.png',
     usefulLinks: APP_IMAGES_ENDPOINT + 'UsefulLinks.png',
     schooling: APP_IMAGES_ENDPOINT + 'Schooling.png',
+    sosinfra: APP_IMAGES_ENDPOINT + 'SOSInfra.png',
   },
   websites: {
     amicale: AMICALE_SERVER,
@@ -94,6 +95,8 @@ export default {
     yearlyPlanning:
       'https://wiki.etud.insa-toulouse.fr/books/quotidien/page/planning-de-lannee-en-cours',
     schooling: 'https://mascolarite.insa-toulouse.fr/',
+    wikiSosInfra:
+      'https://wiki.etud.insa-toulouse.fr/books/ressources-insa/page/signaler-un-probleme-dans-un-batiment-chauffage-lumiere',
   },
   about: {
     appstore: 'https://apps.apple.com/us/app/campus-amicale-insat/id1477722148',

--- a/src/utils/Services.ts
+++ b/src/utils/Services.ts
@@ -62,6 +62,7 @@ export const SERVICES_KEY = {
   WASHERS: 'washers',
   DRYERS: 'dryers',
   SCHOOLING: 'schooling',
+  SOS_INFRA: 'sosinfra',
 };
 
 export const SERVICES_CATEGORIES_KEY = {
@@ -291,6 +292,17 @@ export function getINSAServices(
         onPress(MainRoutes.Website, {
           host: Urls.websites.schooling,
           title: i18n.t('screens.websites.schooling'),
+        }),
+    },
+    {
+      key: SERVICES_KEY.SOS_INFRA,
+      title: i18n.t('screens.websites.sosinfra'),
+      subtitle: i18n.t('screens.services.descriptions.sosinfra'),
+      image: Urls.images.sosinfra,
+      onPress: () =>
+        onPress(MainRoutes.Website, {
+          host: Urls.websites.wikiSosInfra,
+          title: i18n.t('screens.websites.sosinfra'),
         }),
     },
   ];


### PR DESCRIPTION
Adds a service pointing to the SOS-infra wiki page, the normal website requiring VPN access. In the future, this should open the device's email client with a template.

Currently, the image is a copy of Equipment, pending logo.