### PR TITLE
fix(android): undeterministic crashes after opening other apps

### DIFF
--- a/android/app/src/main/java/fr/amicaleinsat/application/MainActivity.java
+++ b/android/app/src/main/java/fr/amicaleinsat/application/MainActivity.java
@@ -14,7 +14,10 @@ public class MainActivity extends ReactActivity {
    @Override
     protected void onCreate(Bundle savedInstanceState) {
         SplashScreen.show(this, R.style.SplashScreenTheme);
-        super.onCreate(savedInstanceState);
+        // Using the saved state caused crashes. This is a workaround.
+        // See https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067
+        // super.onCreate(savedInstanceState);
+        super.onCreate(null);
     }
 
     /**


### PR DESCRIPTION
See https://github.com/software-mansion/react-native-screens/issues/17

Only affects Android devices.

This prevents the app from retrieving state from Android State Shards after the Activity has been discarded, for example when the user has opened other apps and the OS has effectively closed the app. The consequence of this is that this state is not restored (ie the app starts normally), which is better than the app crashing.

Fixes #20