### PR TITLE
fix: club list crash when rotated

### DIFF
--- a/src/components/Screens/WebSectionList.tsx
+++ b/src/components/Screens/WebSectionList.tsx
@@ -25,6 +25,7 @@ import {
   SectionListProps,
   StyleSheet,
   SectionList,
+  useWindowDimensions,
 } from 'react-native';
 import ErrorView, { ErrorProps } from './ErrorView';
 import RequestScreen, { RequestScreenProps } from './RequestScreen';
@@ -83,14 +84,15 @@ const styles = StyleSheet.create({
  * To force the component to update, change the value of updateData.
  */
 function WebSectionList<ItemT, RawData>(props: Props<ItemT, RawData>) {
+  const { width, height: screenHeight } = useWindowDimensions();
   const getItemLayout = (
-    height: number,
+    itemHeight: number,
     _data: Array<SectionListData<ItemT>> | null,
     index: number
   ): { length: number; offset: number; index: number } => {
     return {
-      length: height,
-      offset: height * index,
+      length: itemHeight,
+      offset: itemHeight * index,
       index,
     };
   };
@@ -127,6 +129,7 @@ function WebSectionList<ItemT, RawData>(props: Props<ItemT, RawData>) {
     return (
       <SectionList
         {...props}
+        key={`${width}-${screenHeight}`} // Force re-render on orientation change
         sections={dataset}
         renderItem={props.renderItem}
         style={styles.container}

--- a/src/screens/Amicale/Clubs/ClubListScreen.tsx
+++ b/src/screens/Amicale/Clubs/ClubListScreen.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { useLayoutEffect, useRef, useState } from 'react';
-import { Platform } from 'react-native';
+import { Platform, useWindowDimensions } from 'react-native';
 import { Searchbar } from 'react-native-paper';
 import i18n from 'i18n-js';
 import ClubListItem from '../../../components/Lists/Clubs/ClubListItem';
@@ -59,9 +59,9 @@ type ResponseType = {
   clubs: Array<Club>;
 };
 
-const LIST_ITEM_HEIGHT = 96;
-
 function ClubListScreen() {
+  const { height } = useWindowDimensions();
+  const LIST_ITEM_HEIGHT = Math.min(96, height * 0.15); // Responsive height with max cap
   const navigation = useNavigation();
   const request = useAuthenticatedRequest<ResponseType>('clubs');
   const [currentlySelectedCategories, setCurrentlySelectedCategories] =


### PR DESCRIPTION
The fixed `LIST_ITEM_HEIGHT = 96` caused layout calculation issues during iPad rotation. React Native's layout system couldn't properly recalculate item positions when the screen dimensions changed.

Fixes #147 

Only tested on iOS