### PR TITLE
feat(android): support non-portrait orientations

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
                 android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
                 android:launchMode="singleTask"
                 android:windowSoftInputMode="adjustResize"
-                android:screenOrientation="portrait"
+                android:screenOrientation="unspecified"
                 android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>


### PR DESCRIPTION
> system ignores the following values of this attribute for apps that target Android 16 (API level 36): portrait [...]

https://developer.android.com/guide/topics/manifest/activity-element.html#screen

Tested in Android emulator