### PR TITLE
ci: cache npm dependencies

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - uses: szenius/set-timezone@v1.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - name: Get tag

--- a/package.json
+++ b/package.json
@@ -141,5 +141,6 @@
   },
   "engines": {
     "node": ">= 22.11.0"
-  }
+  },
+  "packageManager": "npm"
 }


### PR DESCRIPTION
See https://github.com/actions/setup-node

Cuts install time in CI/CD from about a minute to about 15 seconds