### PR TITLE
fix(android): safe area free crash

### DIFF
--- a/android/app/src/main/java/fr/amicaleinsat/application/MainActivity.kt
+++ b/android/app/src/main/java/fr/amicaleinsat/application/MainActivity.kt
@@ -17,7 +17,8 @@ class MainActivity : ReactActivity() {
   // From https://github.com/software-mansion/react-native-screens?tab=readme-ov-file#android
   override fun onCreate(savedInstanceState: Bundle?) {
     supportFragmentManager.fragmentFactory = RNScreensFragmentFactory()
-    super.onCreate(savedInstanceState);
+    // passing savedInstanceState leads to rn-safe-area-context attempting a free that crashes sometimes
+    super.onCreate(null);
   }
 }
 


### PR DESCRIPTION
See #158. This might prevent `rn-safe-area-context` from attempting to restore the state, and trying a bad `free`.