### PR TITLE
chore(android): android edge to edge in gradle properties

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -45,4 +45,4 @@ hermesEnabled=true
 # Use this property to enable edge-to-edge display support.
 # This allows your app to draw behind system bars for an immersive UI.
 # Note: Only works with ReactActivity and should not be used with custom Activity.
-edgeToEdgeEnabled=false
+edgeToEdgeEnabled=true


### PR DESCRIPTION
Google Play is saying the app isn't edge to edge. We already made the changes related to safe-area. This PR enables it at the gradle level.